### PR TITLE
Rollout Stats

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,5 +2,6 @@
 .gitignore
 Dockerfile
 .dockerignore
+output
 LICENSE
 README.md

--- a/.gitignore
+++ b/.gitignore
@@ -159,5 +159,5 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
-# VSCode
-.vscode
+# Container Output
+output

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# RL-Plane
+# Reinforcement Learning for the Clearpath Jackal
+
+The goal of this project is to provide an environment to train an agent to move the [Clearpath Jackal](https://clearpathrobotics.com/jackal-small-unmanned-ground-vehicle/) robot without colliding into walls.
+
+Uses [Stable-Baselines3](https://stable-baselines3.readthedocs.io/en/master/), [ROS 2](https://www.ros.org/), [Gazebo Classic](https://classic.gazebosim.org/), and the [Clearpath Jackal ROS Packages](https://github.com/jackal) within the container.
+
+## System Requirements
+
+[Docker](https://www.docker.com/) must be installed on your system.
+
+## Building the Container Image
+
+Run the following command in the repo folder.
+
+```bash
+docker build . -t rlcj
+```
+
+## Training the Agents in the Containers
+
+The `docker-compose.yaml` file can be used to spin up the image just built. The output of the containers (logs and checkpoints) can be found in the `./output` folder by default.
+
+```bash
+docker compose up -d
+```
+
+There are four environment variables that can be used to configure a container.
+
+* `RLCJ_ALGORITHM` - Required. Choose from `A2C`, `PPO`, and `TD3` reinforcement learning algorithms.
+* `RLCJ_OUTPUT_PATH` - Optional. Defaults to `/tmp/rl_out`. Location inside of the container to output logs and checkpoint to.
+* `RLCJ_CHECKPOINT_FREQUENCY` - Optional. Defaults to `1000`. How often to save a checkpoint of the model being trained..
+* `RLCJ_TIMESTEPS` - Optional. Defaults to `1000000`. How many timesteps to train the agent for.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,17 +4,17 @@ services:
     environment:
       - RLCJ_ALGORITHM=A2C
     volumes:
-      - /tmp/a2c_out:/tmp/rl_out
+      - ./output/a2c:/tmp/rl_out
   ppo:
     image: rlcj
     environment:
       - RLCJ_ALGORITHM=PPO
     volumes:
-      - /tmp/ppo_out:/tmp/rl_out
+      - ./output/ppo:/tmp/rl_out
   td3:
     image: rlcj
     environment:
       - RLCJ_ALGORITHM=TD3
     volumes:
-      - /tmp/td3_out:/tmp/rl_out
+      - ./output/td3:/tmp/rl_out
   

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
     environment:
       - RLCJ_ALGORITHM=A2C
       # - RLCJ_OUTPUT_PATH=/tmp/rl_out
-      # - RLCJ_CHECKPOINT_FREQUENCY=1000
+      # - RLCJ_CHECKPOINT_FREQUENCY=100000
       # - RLCJ_TIMESTEPS=1000000
     volumes:
       - ./output/a2c:/tmp/rl_out
@@ -13,7 +13,7 @@ services:
     environment:
       - RLCJ_ALGORITHM=PPO
       # - RLCJ_OUTPUT_PATH=/tmp/rl_out
-      # - RLCJ_CHECKPOINT_FREQUENCY=1000
+      # - RLCJ_CHECKPOINT_FREQUENCY=100000
       # - RLCJ_TIMESTEPS=1000000
     volumes:
       - ./output/ppo:/tmp/rl_out
@@ -22,7 +22,7 @@ services:
     environment:
       - RLCJ_ALGORITHM=TD3
       # - RLCJ_OUTPUT_PATH=/tmp/rl_out
-      # - RLCJ_CHECKPOINT_FREQUENCY=1000
+      # - RLCJ_CHECKPOINT_FREQUENCY=100000
       # - RLCJ_TIMESTEPS=1000000
     volumes:
       - ./output/td3:/tmp/rl_out

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,18 +3,27 @@ services:
     image: rlcj
     environment:
       - RLCJ_ALGORITHM=A2C
+      # - RLCJ_OUTPUT_PATH=/tmp/rl_out
+      # - RLCJ_CHECKPOINT_FREQUENCY=1000
+      # - RLCJ_TIMESTEPS=1000000
     volumes:
       - ./output/a2c:/tmp/rl_out
   ppo:
     image: rlcj
     environment:
       - RLCJ_ALGORITHM=PPO
+      # - RLCJ_OUTPUT_PATH=/tmp/rl_out
+      # - RLCJ_CHECKPOINT_FREQUENCY=1000
+      # - RLCJ_TIMESTEPS=1000000
     volumes:
       - ./output/ppo:/tmp/rl_out
   td3:
     image: rlcj
     environment:
       - RLCJ_ALGORITHM=TD3
+      # - RLCJ_OUTPUT_PATH=/tmp/rl_out
+      # - RLCJ_CHECKPOINT_FREQUENCY=1000
+      # - RLCJ_TIMESTEPS=1000000
     volumes:
       - ./output/td3:/tmp/rl_out
   

--- a/rlcj/agent.py
+++ b/rlcj/agent.py
@@ -28,8 +28,8 @@ def get_model(algorithm: str | None, env: gym.Env) -> BaseAlgorithm:
 def main():
     algorithm = os.getenv("RLCJ_ALGORITHM")
     output_path = os.getenv("RLCJ_OUTPUT_PATH", "/tmp/rl_out")
-    checkpoint_frequency = os.getenv("RLCJ_CHECKPOINT_FREQUENCY", 1000)
-    timesteps = os.getenv("RLCJ_TIMESTEPS", 1000000)
+    checkpoint_frequency = int(os.getenv("RLCJ_CHECKPOINT_FREQUENCY", 1000))
+    timesteps = int(os.getenv("RLCJ_TIMESTEPS", 1000000))
 
     logger = configure(output_path, ["stdout", "log", "csv"])
     checkpoint_callback = CheckpointCallback(

--- a/rlcj/agent.py
+++ b/rlcj/agent.py
@@ -3,6 +3,7 @@ import gymnasium as gym
 import os
 from stable_baselines3 import A2C, PPO, TD3
 from stable_baselines3.common.base_class import BaseAlgorithm
+from stable_baselines3.common.env_util import make_vec_env
 from stable_baselines3.common.callbacks import CheckpointCallback
 from stable_baselines3.common.logger import configure
 
@@ -39,7 +40,7 @@ def main():
         save_vecnormalize=True,
     )
 
-    env = gym.make("rlcj")
+    env = make_vec_env("rlcj", n_envs=1)
     model = get_model(algorithm, env)
     model.set_logger(logger)
     model.learn(total_timesteps=timesteps, callback=checkpoint_callback)

--- a/rlcj/agent.py
+++ b/rlcj/agent.py
@@ -28,7 +28,7 @@ def get_model(algorithm: str | None, env: gym.Env) -> BaseAlgorithm:
 def main():
     algorithm = os.getenv("RLCJ_ALGORITHM")
     output_path = os.getenv("RLCJ_OUTPUT_PATH", "/tmp/rl_out")
-    checkpoint_frequency = int(os.getenv("RLCJ_CHECKPOINT_FREQUENCY", 1000))
+    checkpoint_frequency = int(os.getenv("RLCJ_CHECKPOINT_FREQUENCY", 100000))
     timesteps = int(os.getenv("RLCJ_TIMESTEPS", 1000000))
 
     logger = configure(output_path, ["stdout", "log", "csv"])


### PR DESCRIPTION
Closes #6

This PR adds a readme, but also switched to use `make_vec_env` when constructing the environment. This should wrap the environment in a `Monitor` and log rollout stats.